### PR TITLE
Create response map as pointer to json unmarshal error.

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -18,6 +18,6 @@ func (cl *Client) CreateFeedItem(item *FeedItem) error {
 		"params[body]":      item.Body,
 		"params[image_url]": item.ImageURL,
 	}
-	rsp := map[string]string{}
+	rsp := &map[string]string{}
 	return cl.request("POST", "/feed", args, rsp)
 }


### PR DESCRIPTION
Currently creating a feed item returns an error as the map type given for response marshalling is not a pointer.